### PR TITLE
Wrap socket responses

### DIFF
--- a/api/src/helios/github/github.go
+++ b/api/src/helios/github/github.go
@@ -15,7 +15,7 @@ import (
 
 var LastEvent Event
 var Users = make(map[string]User)
-var EventChan chan interface{}
+var EventChan chan helios.Message
 
 func loadUsersCSV() error {
 	// Open and parse existing users from the uat file

--- a/api/src/helios/slack/slack.go
+++ b/api/src/helios/slack/slack.go
@@ -8,7 +8,7 @@ import (
 	"github.com/nlopes/slack"
 )
 
-var MessageChann chan interface{}
+var MessageChann chan helios.Message
 
 func Service() helios.ServiceHandler {
 	return func(h *helios.Engine) error {
@@ -56,7 +56,7 @@ func messageHandler(api *slack.Slack, c chan slack.SlackEvent) {
 				if err == nil {
 					channelName = channel.Name
 				}
-				MessageChann <- channelName
+				MessageChann <- helios.NewMessage(channelName)
 			}
 		}
 	}


### PR DESCRIPTION
The following adds a wrapper to the data sent over the socket to include some metadata like a status code, service type, and error messages. It also changes the protocol to send everything using the same message name, "event". I believe this will be easier for a dispatcher to listen and distribute that one socket message and the views can use a `type` attribute to determine if it cares about the payload.

Example payload
`{type: "slack", data: <data from slack service>, error: null}`