### PR TITLE
Add forecast.io credit to display.

### DIFF
--- a/client/src/index.html
+++ b/client/src/index.html
@@ -1,6 +1,7 @@
 <html>
   <body>
     <div id="helios"></div>
+    <div class="credit">Weather data powered by Forecast.io</div>
     <!-- build:dev-only -->
     <script type="text/javascript" src="/app.js"></script>
     <!-- endbuild -->

--- a/client/src/styles/base.styl
+++ b/client/src/styles/base.styl
@@ -150,3 +150,9 @@ body table.weather-graph td
   letter-spacing: -.0625em
   font-weight: bold
   color: rgba(255,255,255,.25)
+
+.credit
+  color: #999
+  font-size .5em
+  position absolute
+  bottom 0


### PR DESCRIPTION
[Resolves #109]

<img width="230" alt="screenshot 2015-10-13 16 00 33" src="https://cloud.githubusercontent.com/assets/1940294/10466789/10942a96-71c4-11e5-8bbc-2fa485600968.png">
